### PR TITLE
eiq-621 enable config ignore during deploy

### DIFF
--- a/scripts/pantheon/drush-commands
+++ b/scripts/pantheon/drush-commands
@@ -32,7 +32,7 @@ fi
 echo "Importing config splits."
 # If config splits are available, import them.
 if [ -f "config/splits/_config_splits/config_split.config_split.config_splits.yml" ] ; then
-  terminus -n drush "$P_SITE.$P_ENV" pm-enable config_split config_filter
+  terminus -n drush "$P_SITE.$P_ENV" pm-enable config_split config_filter config_ignore -y
   terminus -n drush "$P_SITE.$P_ENV" -- config-import --source=config/splits/_config_splits --partial --yes
   terminus -n drush "$P_SITE.$P_ENV" -- cr
     # Partial split imports for PS


### PR DESCRIPTION
**Description:**

We need to enable config_ignore during deploy to ensure that block config doesn't get overridden.