### PR TITLE
eiq-240 Add import of test config on PS for non-live envs

### DIFF
--- a/scripts/pantheon/drush-commands
+++ b/scripts/pantheon/drush-commands
@@ -45,6 +45,9 @@ if [ -f "config/splits/_config_splits/config_split.config_split.config_splits.ym
     terminus -n drush "$P_SITE.$P_ENV" -- cr
     echo "Importing partial local config for PS."
     terminus -n drush --yes "$P_SITE.$P_ENV" -- config-import --partial --source=config/splits/local -y
+    if [[ "$P_ENV" != 'live' ]]; then
+      terminus -n drush --yes "$P_SITE.$P_ENV" -- config-import --partial --source=config/splits/test -y
+    fi
   fi
 fi
 

--- a/scripts/pantheon/drush-commands
+++ b/scripts/pantheon/drush-commands
@@ -46,6 +46,7 @@ if [ -f "config/splits/_config_splits/config_split.config_split.config_splits.ym
     echo "Importing partial local config for PS."
     terminus -n drush --yes "$P_SITE.$P_ENV" -- config-import --partial --source=config/splits/local -y
     if [[ "$P_ENV" != 'live' ]]; then
+      echo "Importing partial test config for PS."
       terminus -n drush --yes "$P_SITE.$P_ENV" -- config-import --partial --source=config/splits/test -y
     fi
   fi


### PR DESCRIPTION
**Description:**

We have a new config split called test. We need it to import on PS for non-live envs.