### PR TITLE
stop content sync from live for now

### DIFF
--- a/scripts/pantheon/deploy_to_test_live
+++ b/scripts/pantheon/deploy_to_test_live
@@ -17,7 +17,7 @@ then
 fi
 if [[ "$PUSH_DEPLOY_ENV" == 'test' ]]
 then
-  terminus -n env:deploy --yes "$TERMINUS_SITE.$PUSH_DEPLOY_ENV" --sync-content
+  terminus -n env:deploy --yes "$TERMINUS_SITE.$PUSH_DEPLOY_ENV"
 fi
 if [[ "$PUSH_DEPLOY_ENV" == 'live' ]]
 then


### PR DESCRIPTION
This may prevent some errors being thrown from running our test config import on the live db