### PR TITLE
Revert "stop content sync from live for now"

### DIFF
--- a/scripts/pantheon/deploy_to_test_live
+++ b/scripts/pantheon/deploy_to_test_live
@@ -17,7 +17,7 @@ then
 fi
 if [[ "$PUSH_DEPLOY_ENV" == 'test' ]]
 then
-  terminus -n env:deploy --yes "$TERMINUS_SITE.$PUSH_DEPLOY_ENV"
+  terminus -n env:deploy --yes "$TERMINUS_SITE.$PUSH_DEPLOY_ENV" --sync-content
 fi
 if [[ "$PUSH_DEPLOY_ENV" == 'live' ]]
 then


### PR DESCRIPTION
Reverts EnsembleIQ/project_ci#15

Add --sync-content back to test deploy, this will pull down the live DB.

We removed it when we were having an issue with test content getting into the Algolia indexes, but that's resolved.